### PR TITLE
Run UM only for failing benchmarks (#1520)

### DIFF
--- a/service/experiment-requests.yaml
+++ b/service/experiment-requests.yaml
@@ -20,6 +20,25 @@
 # Please add new experiment requests towards the top of this file.
 #
 
+- experiment: 2022-10-11-um-3
+  description: "UM fuzzer experiment"
+  fuzzers:
+    - aflplusplus
+    - aflplusplus_um_random_3
+  benchmarks:
+    - bloaty_fuzz_target
+    - curl_curl_fuzzer_http
+    - harfbuzz-1.3.2
+    - lcms-2017-03-21
+    - libjpeg-turbo-07-2017
+    - mbedtls_fuzz_dtlsclient 
+    - openthread-2019-12-23
+    - proj4-2017-08-14
+    - re2-2014-12-09
+    - sqlite3_ossfuzz
+    - vorbis-2017-12-11
+    - zlib_zlib_uncompress_fuzzer 
+
 - experiment: 2022-10-07-um-3b
   description: "UM fuzzer experiment"
   fuzzers:


### PR DESCRIPTION
New experiment to run UM fuzzers for only failing benchmarks.

Co-authored-by: jonathanmetzman <31354670+jonathanmetzman@users.noreply.github.com>